### PR TITLE
feat(observability): add alerting, exporters, healthchecks, Jaeger persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ REDIS_PASSWORD=change_me_redis_secret
 # Grafana Config
 GF_SECURITY_ADMIN_PASSWORD=change_me_admin_secret
 GF_SERVER_ROOT_URL=http://localhost:3000
+
+# Alertmanager — Slack webhook for alert notifications
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL

--- a/alertmanager/alertmanager.yml
+++ b/alertmanager/alertmanager.yml
@@ -1,0 +1,18 @@
+global:
+  resolve_timeout: 5m
+  slack_api_url: "${SLACK_WEBHOOK_URL}"
+
+route:
+  receiver: slack-notifications
+  group_by: [alertname]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+receivers:
+  - name: slack-notifications
+    slack_configs:
+      - channel: "#alerts"
+        send_resolved: true
+        title: '[{{ .Status | toUpper }}] {{ .GroupLabels.alertname }}'
+        text: '{{ range .Alerts }}{{ .Annotations.description }}{{ end }}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,7 @@ services:
     container_name: prometheus
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
       - prometheus_data:/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
@@ -115,6 +116,11 @@ services:
       resources:
         limits: { cpus: "0.5", memory: "512M" }
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   loki:
     image: grafana/loki:3.0.0
@@ -128,6 +134,11 @@ services:
       resources:
         limits: { cpus: "0.5", memory: "512M" }
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3100/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   promtail:
     image: grafana/promtail:3.0.0
@@ -163,8 +174,10 @@ services:
     networks:
       - internal-net
     depends_on:
-      - prometheus
-      - loki
+      prometheus:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
     deploy:
       resources:
         limits: { cpus: "0.5", memory: "256M" }
@@ -176,7 +189,12 @@ services:
     container_name: jaeger
     environment:
       - COLLECTOR_OTLP_ENABLED=true
-      - MEMORY_MAX_TRACES=10000
+      - SPAN_STORAGE_TYPE=badger
+      - BADGER_EPHEMERAL=false
+      - BADGER_DIRECTORY_VALUE=/badger/data
+      - BADGER_DIRECTORY_KEY=/badger/key
+    volumes:
+      - jaeger_data:/badger
     ports:
       # UI port bound to localhost
       - "127.0.0.1:16686:16686"
@@ -187,6 +205,68 @@ services:
         limits: { cpus: "0.5", memory: "512M" }
     restart: unless-stopped
 
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: alertmanager
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+    ports:
+      - "127.0.0.1:9093:9093"
+    networks:
+      - internal-net
+    deploy:
+      resources:
+        limits: { cpus: "0.25", memory: "128M" }
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9093/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  postgres-exporter:
+    image: prom/postgres-exporter:v0.15.0
+    container_name: postgres-exporter
+    environment:
+      DATA_SOURCE_NAME: "postgresql://admin:${POSTGRES_ADMIN_PASSWORD}@postgres:5432/postgres?sslmode=disable"
+    networks:
+      - internal-net
+    depends_on:
+      postgres:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits: { cpus: "0.25", memory: "64M" }
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9187/metrics"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  redis-exporter:
+    image: oliver006/redis_exporter:v1.62.0
+    container_name: redis-exporter
+    environment:
+      REDIS_ADDR: "redis://redis:6379"
+      REDIS_PASSWORD: "${REDIS_PASSWORD}"
+    networks:
+      - internal-net
+    depends_on:
+      - redis
+    deploy:
+      resources:
+        limits: { cpus: "0.25", memory: "64M" }
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9121/metrics"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
 volumes:
   pg_data:
   redis_data:
@@ -194,3 +274,4 @@ volumes:
   grafana_data:
   loki_data:
   promtail_positions:
+  jaeger_data:

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -1,0 +1,38 @@
+groups:
+  - name: base_infra
+    rules:
+      - alert: PostgresDown
+        expr: up{job="postgres"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "PostgreSQL is down"
+          description: "PostgreSQL has been unreachable for more than 1 minute."
+
+      - alert: RedisDown
+        expr: up{job="redis"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Redis is down"
+          description: "Redis has been unreachable for more than 1 minute."
+
+      - alert: DiskUsageHigh
+        expr: node_filesystem_avail_bytes / node_filesystem_size_bytes < 0.15
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk usage above 85%"
+          description: "Available disk space is below 15% on {{ $labels.mountpoint }}."
+
+      - alert: NginxHighErrorRate
+        expr: rate(nginx_http_requests_total{status=~"5.."}[5m]) > 0.1
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High NGINX 5xx error rate"
+          description: "NGINX is returning 5xx errors at {{ $value | humanize }} req/s."

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -2,6 +2,14 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+rule_files:
+  - /etc/prometheus/alerts.yml
+
 scrape_configs:
   # Self-monitoring
   - job_name: 'prometheus'
@@ -25,3 +33,13 @@ scrape_configs:
     relabel_configs:
       - target_label: instance
         replacement: nginx
+
+  # PostgreSQL target
+  - job_name: 'postgres'
+    static_configs:
+      - targets: ['postgres-exporter:9187']
+
+  # Redis target
+  - job_name: 'redis'
+    static_configs:
+      - targets: ['redis-exporter:9121']


### PR DESCRIPTION
## What
Full observability production-readiness pass: alerting pipeline, metrics exporters, service healthchecks, and Jaeger trace persistence.

## Why
- No alerting meant outages were only discovered manually
- Postgres and Redis had no Prometheus exporters — blind spots in metrics
- Loki/Prometheus missing healthchecks blocked proper depends_on chains in Grafana
- Jaeger lost all traces on container restart (in-memory storage)

## How to Test
1. `make up` — all new services should start healthy
2. Check Prometheus targets at http://localhost:9090/targets — `postgres` and `redis` jobs should appear
3. Check Alertmanager UI at http://localhost:9093
4. Restart Jaeger container and verify traces persist in http://localhost:16686
5. Set `SLACK_WEBHOOK_URL` in `.env` and trigger an alert to test the notification pipeline

## Related Issues
Closes #8