### PR TITLE
fix(backup): add integrity verification and offsite sync via rclone

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ REDIS_PASSWORD=change_me_redis_secret
 # Grafana Config
 GF_SECURITY_ADMIN_PASSWORD=change_me_admin_secret
 GF_SERVER_ROOT_URL=http://localhost:3000
+
+# Backup offsite sync: configure rclone with a remote named 'backup'
+# See docs/backup-offsite.md for setup instructions

--- a/docs/backup-offsite.md
+++ b/docs/backup-offsite.md
@@ -1,0 +1,57 @@
+# Offsite Backup Setup
+
+The backup script (`scripts/backup.sh`) supports automatic offsite sync via [rclone](https://rclone.org). When rclone is installed and a remote named `backup` is configured, each backup is automatically synced offsite after local integrity verification.
+
+## Supported Providers
+
+rclone supports 70+ cloud providers. Common choices for a solo-founder stack:
+
+| Provider | Notes |
+|----------|-------|
+| Cloudflare R2 | Free egress, S3-compatible |
+| Backblaze B2 | Very cheap storage |
+| AWS S3 | Standard, well-documented |
+| Google Cloud Storage | Good if already on GCP |
+
+## Setup
+
+### 1. Install rclone
+
+```bash
+curl https://rclone.org/install.sh | sudo bash
+```
+
+### 2. Configure a remote named `backup`
+
+```bash
+rclone config
+# Follow the interactive prompts
+# Name the remote exactly: backup
+```
+
+### 3. Test the connection
+
+```bash
+rclone lsd backup:
+```
+
+### 4. Verify auto-sync is working
+
+```bash
+make backup
+# Look for "Syncing backup to offsite storage..." in the output
+```
+
+## Manual Sync
+
+To manually sync all existing local backups to offsite:
+
+```bash
+rclone sync /backups/postgres backup:postgres-backups/
+```
+
+## Notes
+
+- The script will warn (but not fail) if rclone is unavailable — local backups are always written first
+- Integrity is verified with `gzip -t` before the offsite sync runs
+- The backup script exits non-zero on corrupt files, making it safe to alert on cron failures

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -17,6 +17,27 @@ INFRA_DIR="$(dirname "$(dirname "$(realpath "$0")")")"
 cd "$INFRA_DIR" && docker compose exec -T postgres pg_dumpall -U admin \
   | gzip > "$BACKUP_DIR/full_${TIMESTAMP}.sql.gz"
 
+# Verify backup integrity
+echo "[$(date)] Verifying backup integrity..."
+if ! gzip -t "$BACKUP_DIR/full_${TIMESTAMP}.sql.gz"; then
+  echo "[$(date)] ERROR: Backup file is corrupt or incomplete!" >&2
+  exit 1
+fi
+echo "[$(date)] Integrity check passed."
+
+# Offsite sync (requires rclone configured with a remote named 'backup')
+# See docs/backup-offsite.md for setup instructions
+if command -v rclone &>/dev/null && rclone listremotes | grep -q "^backup:"; then
+  echo "[$(date)] Syncing backup to offsite storage..."
+  if rclone copy "$BACKUP_DIR/full_${TIMESTAMP}.sql.gz" backup:postgres-backups/; then
+    echo "[$(date)] Offsite sync complete."
+  else
+    echo "[$(date)] WARNING: Offsite sync failed — local backup still intact." >&2
+  fi
+else
+  echo "[$(date)] WARNING: rclone not configured — skipping offsite sync. See docs/backup-offsite.md to set up." >&2
+fi
+
 # Prune old backups
 find "$BACKUP_DIR" -name "*.sql.gz" -mtime +$RETENTION_DAYS -delete
 


### PR DESCRIPTION
## What
Add backup integrity verification and optional offsite sync to `scripts/backup.sh`.

## Why
- Backups were local-only — a single disk failure loses both the DB and its backups
- A partial write or full disk produced a corrupt `.sql.gz` that appeared to exist with no error raised

## How to Test
1. `make backup` — should now show integrity check passing
2. Install and configure rclone with a remote named `backup`, then `make backup` — should show offsite sync
3. To test corrupt detection: truncate a `.sql.gz` file and confirm `gzip -t` fails and script exits 1

## Related Issues
Closes #9