### PR TITLE
fix(deps): update postgres-exporter image to prometheuscommunity org

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,7 +232,7 @@ services:
       retries: 3
 
   postgres-exporter:
-    image: prom/postgres-exporter:v0.15.0
+    image: prometheuscommunity/postgres-exporter:v0.15.0
     container_name: postgres-exporter
     environment:
       DATA_SOURCE_NAME: "postgresql://admin:${POSTGRES_ADMIN_PASSWORD}@postgres:5432/postgres?sslmode=disable"


### PR DESCRIPTION
## What
Update `postgres-exporter` image from `prom/postgres-exporter:v0.15.0` to `prometheuscommunity/postgres-exporter:v0.15.0`.

## Why
The image was migrated to a new Docker Hub org. The old `prom/postgres-exporter` path now returns a pull access denied error, breaking `make up`.

## How to Test
1. `make up` — should pull and start `postgres-exporter` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)