### PR TITLE
fix(jaeger): add user: "0" to allow badger storage writes on named volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,7 @@ services:
   jaeger:
     image: jaegertracing/all-in-one:1.56
     container_name: jaeger
+    user: "0"
     environment:
       - COLLECTOR_OTLP_ENABLED=true
       - SPAN_STORAGE_TYPE=badger


### PR DESCRIPTION
## What
Add `user: "0"` to the `jaeger` service in `docker-compose.yml`.

## Why
Docker named volumes are created owned by `root:root`. Jaeger runs as uid `10001` by default and cannot create `/badger/key` or `/badger/data`, causing a fatal `permission denied` crash loop on every start. Running as root is safe — all Jaeger ports are bound to `127.0.0.1`.

## How to Test
1. `docker volume rm base_infra_jaeger_data`
2. `make up`
3. `docker compose ps jaeger` → should show `Up`
4. `docker compose logs jaeger` → no `permission denied` errors

Closes #17