### PR TITLE
docs(readme): update README to reflect current infrastructure state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,46 +2,65 @@
 
 [![GitHub Repository](https://img.shields.io/badge/GitHub-usurachai/base_infra-blue?logo=github)](https://github.com/usurachai/base_infra)
 
-This repository contains the foundational infrastructure layer for the solo-founder architecture. It is **initialized and ready for use**. It provides shared Docker networks, data stores, a reverse proxy, and a full observability stack. Application repositories like `chat-api` and `rag-service` join these networks as `external: true`.
+This repository contains the foundational infrastructure layer for the solo-founder architecture. It provides shared Docker networks, data stores, a reverse proxy, a full observability stack, and alerting. Application repositories join these networks as `external: true`.
 
+---
 
 ## Architecture Overview
 
-**Core Services (8 Containers)**:
-- **NGINX**: Reverse proxy mapping `/api/*` to backend microservices
-- **PostgreSQL 16**: Primary DB with `pgvector` and role-based isolation (`chat_app`, `rag_app`)
-- **Redis 7**: Shared cache and task queue (requires auth)
-- **Prometheus**: Metric scraping and TSDB
-- **Loki**: Log aggregator (single process mode)
-- **Promtail**: Scrapes all Docker logs via socket and pushes to Loki
-- **Grafana**: Dashboarding (logs + metrics)
-- **Jaeger**: OpenTelemetry distributed tracing
+**14 Containers across two tiers:**
+
+### Core Services
+| Container | Image | Role |
+| --- | --- | --- |
+| `nginx` | `openresty/openresty:alpine` | Reverse proxy with Lua body masking, rate limiting, structured JSON logging |
+| `postgres` | `pgvector/pgvector:pg16` | Primary DB with `pgvector` extension and per-app schema isolation |
+| `redis` | `redis:7-alpine` | Shared cache and task queue with AOF persistence |
+
+### Observability
+| Container | Image | Role |
+| --- | --- | --- |
+| `prometheus` | `prom/prometheus:v2.45.0` | Metric scraping and TSDB (15-day retention) |
+| `loki` | `grafana/loki:3.0.0` | Log aggregation (7-day retention) |
+| `promtail` | `grafana/promtail:3.0.0` | Docker socket log collector → Loki |
+| `grafana` | `grafana/grafana:10.4.1` | Dashboarding (metrics + logs) |
+| `jaeger` | `jaegertracing/all-in-one:1.56` | Distributed tracing via OTLP, Badger persistent storage |
+| `alertmanager` | `prom/alertmanager:v0.27.0` | Alert routing (Prometheus → Slack / email) |
+
+### Exporters
+| Container | Image | Role |
+| --- | --- | --- |
+| `nginx-exporter` | `nginx/nginx-prometheus-exporter:1.1.0` | NGINX stub status → Prometheus |
+| `postgres-exporter` | `prometheuscommunity/postgres-exporter:v0.15.0` | PostgreSQL metrics → Prometheus |
+| `redis-exporter` | `oliver006/redis_exporter:v1.62.0` | Redis metrics → Prometheus |
 
 ### Networks
 
-1. `frontend-net`: NGINX reverse-proxying down to app backends
-2. `internal-net`: Secure lane for apps to reach PostgreSQL/Redis/Observability tools
+1. `frontend-net` — NGINX only. Entry point for all inbound traffic.
+2. `internal-net` — Private. All services (apps, databases, observability) communicate here.
+
+App repos declare both networks as `external: true` in their own `docker-compose.yml`. NGINX proxies to them by container hostname.
 
 ---
 
 ## Quick Start
 
-1. **Clone this repo**.
+1. **Clone this repo**
 2. **Configure environment variables**:
    ```bash
    cp .env.example .env
-   # Edit .env and change all passwords!
+   # Edit .env — change all passwords before starting
    ```
 3. **Start the infrastructure**:
    ```bash
    make up
    ```
-4. **Verify Health**:
+4. **Verify health**:
    ```bash
    make health
    ```
 
-*Note: Initially, NGINX may return `502 Bad Gateway` on `/api/chat/` until your app repositories are also booted and joined to the networks.*
+> **Note:** NGINX will return `502 Bad Gateway` on `/api/*` routes until app containers are running and joined to the networks.
 
 ---
 
@@ -49,34 +68,85 @@ This repository contains the foundational infrastructure layer for the solo-foun
 
 | Service | Host Binding | Access Method |
 | --- | --- | --- |
-| NGINX | `:80`, `:443` | Public (Your Domain / IP) |
-| Grafana | `127.0.0.1:3000` | SSH Tunnel / Tailscale |
-| Prometheus | `127.0.0.1:9090` | SSH Tunnel / Tailscale |
-| Jaeger UI | `127.0.0.1:16686`| SSH Tunnel / Tailscale |
+| NGINX | `:80`, `:443` | Public (your domain / IP) |
+| Grafana | `127.0.0.1:3000` | SSH tunnel / Tailscale |
+| Prometheus | `127.0.0.1:9090` | SSH tunnel / Tailscale |
+| Jaeger UI | `127.0.0.1:16686` | SSH tunnel / Tailscale |
+| Alertmanager | `127.0.0.1:9093` | SSH tunnel / Tailscale |
+| PostgreSQL | `127.0.0.1:5432` | `make db-shell` or tunnel |
 
-*PostgreSQL, Redis, Loki, and Promtail are **not** exposed to the host by design. Connect via `docker compose exec` or a container on `internal-net`.*
+*Redis, Loki, Promtail, and exporters are not exposed to the host by design.*
 
 ---
 
-## Promtail Log Collection
+## PostgreSQL Role Isolation
 
-This setup uses **Promtail** as a centralized log collector for Docker:
-- Automatically mounts `/var/run/docker.sock` to discover running containers across **all** compose projects.
-- Pulls stdout/stderr and enriches logs with compose labels (e.g. `compose_project`, `compose_service`).
-- Sends logs to Loki.
-- Unlike the Docker log driver plugin, this does **not** require modifying `/etc/docker/daemon.json` on the host machine.
+Each app gets a dedicated schema and role within the shared `meowdb` database:
+
+| Role | Schema | App |
+| --- | --- | --- |
+| `zenconnect_app` | `zenconnect` | zendesk-agent-api |
+| `meowrag_app` | `meowrag` | rag-api |
+
+Roles have no `CREATEDB` and are scoped to their own schema via `ALTER ROLE ... SET search_path`. The `public` schema has `CREATE` revoked.
+
+---
+
+## Observability Pipeline
+
+```
+Docker containers
+   └── Promtail (Docker socket)
+           └── Loki ──────────────┐
+                                  ▼
+Prometheus ◄── exporters     Grafana (dashboards)
+   └── alerting rules
+           └── Alertmanager (Slack / email)
+
+App services ──OTLP──► Jaeger (Badger storage)
+```
+
+---
+
+## Backups
+
+`make backup` (or cron at `0 3 * * *`) runs `scripts/backup.sh`:
+
+1. `pg_dumpall` → gzipped to `/backups/postgres/`
+2. Integrity check via `gzip -t`
+3. Offsite sync via `rclone copy` to `backup:postgres-backups/` (if rclone is configured)
+4. Local retention: 7 days
+
+See [`docs/backup-offsite.md`](./docs/backup-offsite.md) for rclone setup.
 
 ---
 
 ## Daily Operations
 
-Use the included `Makefile` to manage the infrastructure:
-
 ```bash
-make status  # View status and resource consumption
-make logs    # Tail logs of all infra containers
-make backup  # Manually run a PostgreSQL pg_dumpall
-make health  # Run the ping/HTTP healthchecks
+make up              # Start all services
+make down            # Stop all services
+make status          # View container status and resource usage
+make logs svc=nginx  # Tail logs for a specific service
+make health          # Run healthchecks against all components
+make backup          # Manually trigger a PostgreSQL backup
+make db-shell        # Open PostgreSQL interactive shell
 ```
+
+---
+
+## Adding a New App
+
+1. In your app's `docker-compose.yml`, declare the networks as external:
+   ```yaml
+   networks:
+     frontend-net:
+       external: true
+     internal-net:
+       external: true
+   ```
+2. Add an NGINX `location` block in `nginx/conf.d/routes.conf` pointing to your container hostname
+3. Add a Prometheus scrape job in `prometheus/prometheus.yml` if your app exposes `/metrics`
+4. Add a role and schema to `postgres/init.sh` if your app uses PostgreSQL
 
 See [Infrastructure Design_solo.md](./Infrastructure%20Design_solo.md) for deeper architectural reasoning.


### PR DESCRIPTION
## What
Rewrote README.md to accurately reflect the current 14-container stack.

## Why
The old README described 8 containers and referenced `chat_app`/`rag_app` roles that no longer exist, making it misleading for anyone onboarding or returning to the project.

## Changes
- Container tables reorganized into Core / Observability / Exporters sections (8 → 14 services)
- PostgreSQL roles updated to `zenconnect_app` / `meowrag_app` in `meowdb`
- Jaeger noted as using Badger persistent storage
- Backup section documents integrity check + rclone offsite sync
- Port map expanded with Alertmanager and PostgreSQL
- Added observability pipeline diagram
- Added "Adding a New App" guide

## How to Test
Read the README and verify it matches `docker compose ps` output.

Closes #19