### PR TITLE
fix(alertmanager): add env_file and --config.expand-env to fix crash loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,11 +213,13 @@ services:
   alertmanager:
     image: prom/alertmanager:v0.27.0
     container_name: alertmanager
+    env_file: .env
     volumes:
       - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
     command:
       - "--config.file=/etc/alertmanager/alertmanager.yml"
       - "--storage.path=/alertmanager"
+      - "--config.expand-env=true"
     ports:
       - "127.0.0.1:9093:9093"
     networks:


### PR DESCRIPTION
## What
Add `env_file: .env` and `--config.expand-env=true` to the alertmanager service.

## Why
Alertmanager was crash-looping with `unsupported scheme "" for URL` because `${SLACK_WEBHOOK_URL}` in `alertmanager.yml` was not being expanded — the env var wasn't passed into the container and expansion wasn't enabled.

## How to Test
1. Set `SLACK_WEBHOOK_URL` in `.env` with a real Slack webhook URL
2. `docker compose up -d alertmanager`
3. `docker compose ps alertmanager` — should show `healthy`, not `Restarting`

## Related Issues
Closes #22